### PR TITLE
CompatHelper: bump compat for TestSetExtensions in [extras] to 4, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -44,7 +44,7 @@ Suppressor = "0.2"
 TaylorDiff = "0.2"
 TaylorSeries = "0.12 - 0.30"
 Test = "1.10"
-TestSetExtensions = "2"
+TestSetExtensions = "2, 4"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
This pull request changes the compat entry for the `TestSetExtensions` package from `2` to `2, 4`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.